### PR TITLE
Agrupamento de tarefas por prioridade com accordion estilizado

### DIFF
--- a/src/app/dashboard/Dashboard.module.css
+++ b/src/app/dashboard/Dashboard.module.css
@@ -63,6 +63,9 @@
   
   .taskList {
     margin-top: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
   }
   
   .empty {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,14 +7,9 @@ import AddTaskForm from '@/components/AddTaskForm/AddTaskForm';
 import styles from './Dashboard.module.css';
 import SearchBar from '@/components/SearchBar/SearchBar';
 import Header from '@/components/Header/Header';
+import { Task } from '@/types/task';
+import PriorityAccordion from '@/components/PriorityAccordion/PriorityAccordion';
 
-
-type Task = {
-  id: number;
-  title: string;
-  description: string;
-  completed: boolean;
-};
 
 export default function DashboardPage() {
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -74,7 +69,14 @@ export default function DashboardPage() {
   const filteredTasks = tasks.filter(task =>
     `${task.title} ${task.description}`.toLowerCase().includes(query.toLowerCase())
   );
-  
+
+  const priorities: ('alta' | 'média' | 'baixa')[] = ['alta', 'média', 'baixa'];
+
+  const groupedTasks = priorities.map(priority => ({
+    priority,
+    tasks: filteredTasks.filter(task => task.priority === priority)
+  }));
+
 
   useEffect(() => {
     fetchTasks();
@@ -82,35 +84,29 @@ export default function DashboardPage() {
 
   return (
     <>
-    <Header userName="Fulano" />
+      <Header userName="Fulano" />
 
-    <main className={styles.dashboard}>
-      <h1 className={styles.title}>Suas Tarefas</h1>
-  
-      {/* <SearchBar query={query} onChange={setQuery} /> */}
-      <SearchBar query={query} onChange={setQuery}>
-  <AddTaskForm onSubmit={createTask} />
-</SearchBar>
+      <main className={styles.dashboard}>
+        <h1 className={styles.title}>Suas Tarefas</h1>
 
-  
-      <div className={styles.taskList}>
-        {filteredTasks.length === 0 ? (
-          <p className={styles.empty}>Nenhuma tarefa encontrada.</p>
-        ) : (
-          filteredTasks.map(task => (
-            <TaskItem
-              key={task.id}
-              task={task}
-              onDelete={deleteTask}
-              onToggle={toggleTask}
-            />
-          ))
-        )}
-      </div>
-  
-      {/* <AddTaskForm onSubmit={createTask} /> */}
-    </main>
+        <SearchBar query={query} onChange={setQuery}>
+          <AddTaskForm onSubmit={createTask} />
+        </SearchBar>
+
+
+        {groupedTasks.map(group => (
+          <PriorityAccordion
+            key={group.priority}
+            priority={group.priority}
+            tasks={group.tasks}
+            onDelete={deleteTask}
+            onToggle={toggleTask}
+          />
+        ))}
+
+
+      </main>
     </>
   );
-  
+
 }

--- a/src/components/AddTaskForm/AddTaskForm.module.css
+++ b/src/components/AddTaskForm/AddTaskForm.module.css
@@ -33,6 +33,12 @@
     width: 320px;
     display: none;
   }
+
+  .formWrapper form {
+    display: flex;
+    flex-direction: column;
+    gap: 13px;
+  }
   
   .formWrapper.open {
     display: block;

--- a/src/components/AddTaskForm/AddTaskForm.tsx
+++ b/src/components/AddTaskForm/AddTaskForm.tsx
@@ -10,7 +10,7 @@ export default function AddTaskForm({ onSubmit }: Props) {
     const [isOpen, setIsOpen] = useState(false);
     const [title, setTitle] = useState('');
     const [description, setDescription] = useState('');
-    const [priority, setPriority] = useState('média');
+    const [priority, setPriority] = useState('alta');
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -25,7 +25,7 @@ export default function AddTaskForm({ onSubmit }: Props) {
     return (
         <div className={styles.wrapper}>
             <button onClick={() => setIsOpen(prev => !prev)} className={styles.fab}>
-                {isOpen ? 'Cancelar' : 'Adicionar'}
+                {isOpen ? 'Cancelar' : 'Adicionar tarefa +'}
             </button>
 
             <div className={`${styles.formWrapper} ${isOpen ? styles.open : ''}`}>

--- a/src/components/PriorityAccordion/PriorityAccordion.module.css
+++ b/src/components/PriorityAccordion/PriorityAccordion.module.css
@@ -1,0 +1,23 @@
+.accordion {
+  margin-bottom: 1rem;
+  padding: 0.5rem;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.accordion[open] {
+  /* background-color: #fff; */
+}
+
+.accordionHeader {
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.empty {
+  color: #666;
+  font-style: italic;
+  margin-left: 1rem;
+}

--- a/src/components/PriorityAccordion/PriorityAccordion.tsx
+++ b/src/components/PriorityAccordion/PriorityAccordion.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { FC } from 'react';
+import TaskItem from '../TaskItem/TaskItem';
+import styles from './PriorityAccordion.module.css';
+import { Task } from '@/types/task';
+
+type Props = {
+  priority: 'alta' | 'média' | 'baixa';
+  tasks: Task[];
+  onDelete: (id: number) => void;
+  onToggle: (task: Task) => void;
+};
+
+const PriorityAccordion: FC<Props> = ({ priority, tasks, onDelete, onToggle }) => {
+  const capitalized = priority.charAt(0).toUpperCase() + priority.slice(1);
+
+  return (
+    <details open className={styles.accordion}>
+      <summary className={styles.accordionHeader}>
+        {capitalized} prioridade ({tasks.length})
+      </summary>
+      {tasks.length === 0 ? (
+        <p className={styles.empty}>Nenhuma tarefa de prioridade {priority}.</p>
+      ) : (
+        tasks.map(task => (
+          <TaskItem key={task.id} task={task} onDelete={onDelete} onToggle={onToggle} />
+        ))
+      )}
+    </details>
+  );
+};
+
+export default PriorityAccordion;

--- a/src/components/TaskItem/TaskItem.module.css
+++ b/src/components/TaskItem/TaskItem.module.css
@@ -1,143 +1,79 @@
-.taskItem {
-    padding: 1.25rem;
-    border-radius: 12px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background-color: #1f1f1f;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    color: #fff;
-    gap: 1rem;
-    flex-wrap: wrap;
-  }
-  
-  .taskItem.completed {
-    opacity: 0.6;
-  }
-  
-  .left {
-    display: flex;
-    gap: 1rem;
-    flex: 1;
-    align-items: flex-start;
-  }
-  
-  .priority {
-    padding: 0.2rem 0.6rem;
-    border-radius: 8px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: capitalize;
-    min-width: 60px;
-    text-align: center;
-  }
-  
-  .baixa {
-    background-color: #22c55e;
-    color: #fff;
-  }
-  
-  .média {
-    background-color: #eab308;
-    color: #000;
-  }
-  
-  .alta {
-    background-color: #ef4444;
-    color: #fff;
-  }
-  
-  .taskContent {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-    max-width: 500px;
-  }
-  
-  .taskTitle {
-    font-weight: 600;
-    font-size: 1.125rem;
-  }
-  
-  .taskTitle.completed {
-    text-decoration: line-through;
-    color: #888;
-  }
-  
-  .taskDescription {
-    font-size: 0.9rem;
-    color: #ccc;
-  }
-  
-  .taskDescription.completed {
-    text-decoration: line-through;
-    color: #888;
-  }
-  
-  .buttonsContainer {
-    display: flex;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-  }
-  
-  .button {
-    font-size: 0.8rem;
-    padding: 0.5rem 0.8rem;
-    border-radius: 6px;
-    cursor: pointer;
-    border: none;
-    transition: background-color 0.2s ease, transform 0.2s ease;
-    font-weight: 500;
-  }
-  
-  .button:hover {
-    transform: translateY(-2px);
-  }
-  
-  .buttonConclude {
-    background-color: #4b6ef5;
-    color: white;
-  }
-  
-  .buttonDelete {
-    background-color: #d32f2f;
-    color: white;
-  }
-  
-  .buttonConclude:hover {
-    background-color: #3a52c5;
-  }
-  
-  .buttonDelete:hover {
-    background-color: #b71c1c;
-  }
-  
+.taskRow {
+  display: flex;
+  align-items: flex-start;
+  padding: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background-color 0.2s ease;
+  color: #f1f1f1;
+  gap: 1rem;
+}
 
-  .priorityTag {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.3rem 0.7rem;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: capitalize;
-    background-color: #333;
-    color: #fff;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  }
-  
-  .baixa {
-    background-color: #22c55e;
-  }
-  
-  .média {
-    background-color: #eab308;
-    color: #000;
-  }
-  
-  .alta {
-    background-color: #ef4444;
-  }
-  
+.taskRow:hover {
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.checkboxArea {
+  padding-top: 0.4rem;
+}
+
+.checkbox {
+  width: 1.1rem;
+  height: 1.1rem;
+  accent-color: #3b82f6;
+  cursor: pointer;
+}
+
+.taskDetails {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.taskHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.taskTitle {
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.taskDescription {
+  font-size: 0.9rem;
+  color: #aaa;
+}
+
+.taskRow.completed .taskTitle,
+.taskRow.completed .taskDescription {
+  text-decoration: line-through;
+  opacity: 0.6;
+}
+
+.taskActions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.button {
+  font-size: 0.8rem;
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.buttonDelete {
+  background-color: transparent;
+  color: #ef4444;
+}
+
+.buttonDelete:hover {
+  color: #dc2626;
+  transform: scale(1.1);
+}
+

--- a/src/components/TaskItem/TaskItem.tsx
+++ b/src/components/TaskItem/TaskItem.tsx
@@ -1,14 +1,10 @@
 'use client';
 import { FC } from 'react';
 import styles from './TaskItem.module.css';
+import { Task } from '@/types/task';
+import { Trash2 } from 'lucide-react';
 
-type Task = {
-  id: number;
-  title: string;
-  description: string;
-  completed: boolean;
-  priority?: 'baixa' | 'média' | 'alta'; // agora opcional
-};
+
 
 type Props = {
   task: Task;
@@ -16,49 +12,33 @@ type Props = {
   onToggle: (task: Task) => void;
 };
 
-const getPriorityIcon = (priority: 'baixa' | 'média' | 'alta') => {
-  switch (priority) {
-    case 'baixa':
-      return '🟢'; // ou algum ícone SVG no futuro
-    case 'média':
-      return '🟡';
-    case 'alta':
-      return '🔴';
-    default:
-      return '';
-  }
-};
-
 
 const TaskItem: FC<Props> = ({ task, onDelete, onToggle }) => {
   return (
-    <div className={`${styles.taskItem} ${task.completed ? styles.completed : ''}`}>
-
-      <div className={styles.left}>
-        {task.priority && (
-          <span className={`${styles.priorityTag} ${styles[task.priority]}`}>
-            {getPriorityIcon(task.priority)} {task.priority}
-          </span>
-        )}
-
-        <div className={styles.taskContent}>
-          <h2 className={`${styles.taskTitle} ${task.completed ? styles.completed : ''}`}>{task.title}</h2>
-          <p className={`${styles.taskDescription} ${task.completed ? styles.completed : ''}`}>{task.description}</p>
-        </div>
+    <div className={`${styles.taskRow} ${task.completed ? styles.completed : ''}`}>
+      
+      <div className={styles.checkboxArea}>
+        <input
+          type="checkbox"
+          checked={task.completed}
+          onChange={() => onToggle(task)}
+          className={styles.checkbox}
+        />
       </div>
 
-      <div className={styles.buttonsContainer}>
-        <button
-          onClick={() => onToggle(task)}
-          className={`${styles.button} ${styles.buttonConclude}`}
-        >
-          {task.completed ? 'Desfazer' : 'Concluir'}
-        </button>
+      <div className={styles.taskDetails}>
+        <div className={styles.taskHeader}>
+          <h3 className={styles.taskTitle}>{task.title}</h3>          
+        </div>
+        <p className={styles.taskDescription}>{task.description}</p>
+      </div>
+
+      <div className={styles.taskActions}>
         <button
           onClick={() => onDelete(task.id)}
           className={`${styles.button} ${styles.buttonDelete}`}
         >
-          Excluir
+          <Trash2 size={18} />
         </button>
       </div>
     </div>

--- a/src/types/task.tsx
+++ b/src/types/task.tsx
@@ -1,0 +1,8 @@
+export type Task = {
+    id: number;
+    title: string;
+    description: string;
+    completed: boolean;
+    priority: 'baixa' | 'média' | 'alta';
+  };
+  


### PR DESCRIPTION
Organizei as tarefas por prioridade (alta, média, baixa) usando um componente de acordeon, pra facilitar a visualização. Agora cada grupo de tarefas pode ser expandido ou recolhido individualmente.

Também dei uma ajustada no visual dos cards pra combinar melhor com o novo layout, deixando tudo mais limpo e padronizado. O comportamento de concluir e excluir tarefas continua funcionando normalmente, assim como a busca.